### PR TITLE
Store Quote Upon Retrieval

### DIFF
--- a/Payment/Method/MultiSafepayCreditCard.php
+++ b/Payment/Method/MultiSafepayCreditCard.php
@@ -170,13 +170,13 @@ class MultiSafepayCreditCard extends Component\Form
     }
 
     /**
-     * @return Quote
+     * @return Quote|null
      */
     private function getQuote(): ?Quote
     {
         if (!$this->quote) {
             try {
-                return $this->sessionCheckout->getQuote();
+                $this->quote = $this->sessionCheckout->getQuote();
             } catch (NoSuchEntityException | LocalizedException $exception) {
                 $this->logger->logPaymentComponentException($exception);
             }


### PR DESCRIPTION
Storing the quote locally saves having to fetch it from the session every time.