### PR TITLE
fix: #30 Compatibility with Hyva Checkout 1.1.29

### DIFF
--- a/Payment/MethodListExtended.php
+++ b/Payment/MethodListExtended.php
@@ -58,19 +58,18 @@ class MethodListExtended extends MethodList
         EvaluationResultFactory $evaluationResultFactory,
         Config $config,
         QuoteRepository $quoteRepository,
-        ?SystemConfigExperimental $experimentalHyvaCheckoutConfig,
-        ?PaymentMethodManagementInterface $paymentMethodManagement
+        ?SystemConfigExperimental $experimentalHyvaCheckoutConfig = null,
+        ?PaymentMethodManagementInterface $paymentMethodManagement = null
     ) {
         $this->quoteRepository = $quoteRepository;
         $this->config = $config;
+
         parent::__construct(
             $sessionCheckout,
             $cartRepository,
             $evaluationResultFactory,
-            $this->experimentalHyvaCheckoutConfig = $experimentalHyvaCheckoutConfig
-                ?: ObjectManager::getInstance()->get(SystemConfigExperimental::class),
-            $this->paymentMethodManagement = $paymentMethodManagement
-            ?: ObjectManager::getInstance()->get(PaymentMethodManagementInterface::class)
+            $experimentalHyvaCheckoutConfig,
+            $paymentMethodManagement
         );
     }
 


### PR DESCRIPTION
The fix that was implemented in ticket #31 for MAGWIRE-28 makes the same thought-error as Hyvä made: making a property nullable, but without declaring a default value - thus still requiring it.

Also, the original fix was setting properties straight from the call to the Parent Constructor, that are also set within that Parent Constructor. For readability purposes, and to remove duplicate code (Hyva is doing exactly the same ObjectManager-pull when the new arguments are `null`), I scrapped the ObjectManager-link here and defaulted the constructor arguments to be `null`.
I wonder though, how often Hyvä will call the ObjectManager, since these new parameters are auto-wireable ;-) Maybe requiring these classes, without making them nullable, will also future-proof the code, removing the necessity to update this code as soon as the dependency on the side of Hyvä will become required as well