### PR TITLE
HYVA-45: Prepare changes for the 3.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-03-26
+### Fixed
+- HYVA-44: Fixed an issue where the payment component would show an error after the API Token expired
+
 ## [3.0.0] - 2026-03-18
 ### Added
 - PLGMAG2V2-888: Implemented token-based redirect handling via updated payment/library dependencies

--- a/Util/VersionUtil.php
+++ b/Util/VersionUtil.php
@@ -15,5 +15,5 @@ namespace MultiSafepay\HyvaCheckout\Util;
 
 class VersionUtil
 {
-    public const VERSION = '3.0.0';
+    public const VERSION = '3.0.1';
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "multisafepay/magento2-hyva-checkout",
     "description": "Integrate MultiSafepay payment methods into your Hyvä Checkout",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "type": "magento2-module",
     "license": "OSL-3.0",
     "minimum-stability": "dev",


### PR DESCRIPTION
This pull request releases version 3.0.1 of the `multisafepay/magento2-hyva-checkout` module, addressing a bug related to payment component errors after API token expiration. The version number is updated across the codebase to reflect this new release.

Bug Fix:

* Fixed an issue where the payment component would show an error after the API Token expired (`CHANGELOG.md`).

Version Updates:

* Updated the version constant to `3.0.1` in `VersionUtil.php`.
* Updated the package version to `3.0.1` in `composer.json`.